### PR TITLE
New ECS service type for background job

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ data "template_file" "service_server_container_definition" {
     service_server_memory       = "${var.service_server_memory}"
     service_server_docker_image = "${var.service_server_docker_image}"
     service_container_name      = "${var.service_container_name}"
+    service_container_cmd       = "${var.service_container_cmd}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,9 @@ resource "aws_ecs_task_definition" "service_server" {
   tags                  = "${local.ecs_task_definition_tags}"
 }
 
-
+#------------------------------------------------------
+# Web service which required to listen a specific port
+#------------------------------------------------------
 resource "aws_ecs_service" "service" {
   count = "${var.service_app_port > 0 ? 1 : 0}"
 
@@ -68,6 +70,9 @@ resource "aws_ecs_service" "service" {
   # https://github.com/terraform-providers/terraform-provider-aws/issues/6481
 }
 
+#-----------------------------
+# Background / Worker service
+#-----------------------------
 resource "aws_ecs_service" "service_background" {
   count = "${var.service_app_port > 0 ? 0 : 1}"
 

--- a/task-definition.json.tpl
+++ b/task-definition.json.tpl
@@ -9,6 +9,7 @@
         },
         "entryPoint": null,
         "command": %{ if service_container_cmd == "" }null%{ else }${jsonencode(split(" ", service_container_cmd))}%{ endif },
+%{ if port > 0 }
         "portMappings": [
             {
                 "hostPort": 0,
@@ -16,7 +17,7 @@
                 "containerPort": ${port}
             }
         ],
-        "command": null,
+%{ endif }
         "linuxParameters": null,
         "cpu": ${service_server_cpu},
         "environment": [],

--- a/task-definition.json.tpl
+++ b/task-definition.json.tpl
@@ -8,6 +8,7 @@
             }
         },
         "entryPoint": null,
+        "command": %{ if service_container_cmd == "" }null%{ else }${jsonencode(split(" ", service_container_cmd))}%{ endif },
         "portMappings": [
             {
                 "hostPort": 0,

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,10 @@ variable "project_name" {
 variable "service_container_name" {
   default = "container-name"
 }
+variable "service_container_cmd" {
+  description = "Command to start container (follow Dockerfile's CMD by default)"
+  default = ""
+}
 variable "service_app_port" {
   default = 3000
 }


### PR DESCRIPTION
Changes:
- New variable, `service_container_cmd`, for overwrite the command from Dockerfile's CMD
- Only enable `portMappings` in task definition when valid port ( > 0 ) is entered