### PR TITLE
update task definition to allow task iam role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ resource "aws_ecs_task_definition" "service_server" {
   cpu                   = "${var.task_required_cpu}"
   memory                = "${var.task_required_memory}"
   container_definitions = "${data.template_file.service_server_container_definition.rendered}"
+  task_role_arn         = "${var.task_role_arn}"
   tags                  = "${local.ecs_task_definition_tags}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,10 @@ variable "health_check_grace_period_seconds" {
   default = 0
 }
 
+variable "task_role_arn" {
+  default = ""
+}
+
 variable "ecs_cluster" {
   default = "ecs-cluster-name"
 }


### PR DESCRIPTION
Update
- Allow task role arn to be parsed for task definition creation.
Note
- An empty string (default) for task role arn will still allow task definition to be created.